### PR TITLE
Streamline the creation of orbit area plots

### DIFF
--- a/exptool/analysis/commensurability.py
+++ b/exptool/analysis/commensurability.py
@@ -175,7 +175,7 @@ def calculate_area_array(D,ratio=10.,usex='TX',usey='TY'):
 
 def plot_orbit_areas(Aarr, Rarr, Varr, cmap='magma', savestring=''):
     fig, ax1 = plt.subplots(1,1, figsize=(12,10))
-    cb = ax1.imshow(Aarr.reshape(Rarr.size, Varr.size),
+    cb = ax1.imshow(Aarr.reshape(Rarr.size, Varr.size).T,
             extent=[Rarr.min(), Rarr.max(), Varr.min(), Varr.max()], 
             origin='lower',cmap=cmap, aspect='auto')
     fig.colorbar(cb, label='Normalised Orbit Area')

--- a/exptool/analysis/commensurability.py
+++ b/exptool/analysis/commensurability.py
@@ -113,10 +113,78 @@ def calculate_area(Orbit,ratio=10.,usex='TX',usey='TY'):
 
 
 
+def calculate_area_array(D,ratio=10.,usex='TX',usey='TY'):
+    """calculate the areas of orbits using volume tesselation 
+     make an array of all the areas. Here, we loop through a file of integrated orbits
+
+    inputs
+    --------------------
+    D : a file of integrated orbits, assuming same format as the read_integrations output
+    ratio : (float, default=10.) ratio of minimum side length to maximum to not count toward the area total
+    usex  : (string, default='TX') key in dictionary for x coordinate
+    usey  : (string, default='TY') key in dictionary for y coordinate
+
+    returns
+    -------------------
+    an array of the the area values, each normalized by the maximum circle area
 
 
 
+    todo
+    ------------------
+    1. turn into 3d
 
+    """
+    Aarr = np.array([])
+    points = np.array([[D[usex][x],D[usey][x]] for  x in range(0,len(D[usex]))])
+
+    for i in range(len(points[:,0,0])):
+    # do the triangulation
+        tri = Delaunay(points[i,:,:].T)
+
+
+        A = np.zeros(tri.simplices.shape[0])
+        legs = np.zeros([tri.simplices.shape[0],3])
+
+
+
+        for t in range(0,tri.simplices.shape[0]):
+
+            xvals = tri.simplices[t]
+            x1 = D[usex][i][xvals[0]]
+            x2 = D[usex][i][xvals[1]]
+            x3 = D[usex][i][xvals[2]]
+            y1 = D[usey][i][xvals[0]]
+            y2 = D[usey][i][xvals[1]]
+            y3 = D[usey][i][xvals[2]]
+
+            A[t] = 0.5*((x2-x1)*(y3-y1) - (x3-x1)*(y2-y1))
+
+            tmplegs = np.array([np.sqrt((x1-x2)*(x1-x2) + (y1-y2)*(y1-y2)),\
+                        np.sqrt((x1-x3)*(x1-x3) + (y1-y3)*(y1-y3)),\
+                        np.sqrt((x2-x3)*(x2-x3) + (y2-y3)*(y2-y3))])
+
+            legs[t] = tmplegs[tmplegs.argsort()]
+
+        med = np.median(legs[:,0])
+        include = legs[:,1]/med
+        Aa = np.sum(A[include < ratio])/(np.pi*np.nanmax(D[usex][i])*np.nanmax(D[usex][i]))
+        Aarr = np.append(Aarr, Aa)
+        # this has the normalization in it now
+    return Aarr
+
+def plot_orbit_areas(Aarr, Rarr, Varr, cmap='magma', savestring=''):
+    fig, ax1 = plt.subplots(1,1, figsize=(12,10))
+    cb = ax1.imshow(Aarr.reshape(Rarr.size, Varr.size),
+            extent=[Rarr.min(), Rarr.max(), Varr.min(), Varr.max()], 
+            origin='lower',cmap=cmap, aspect='auto')
+    fig.colorbar(cb, label='Normalised Orbit Area')
+    ax1.set_xlabel('Radius')
+    ax1.set_ylabel('Velocity')
+    if savestring=='':
+        plt.savefig('orbit_area_plot.jpeg')
+    else:
+        plt.savefig(savestring)
 
 # read in orbit integrations
 

--- a/exptool/utils/integrate.py
+++ b/exptool/utils/integrate.py
@@ -349,8 +349,8 @@ def multi_compute_integration(subrads,nprocs,vels,F,\
     twelvth_arg = [0 for i in range(0,nprocs)]
     twelvth_arg[0] = verbose
     #
-    out_vals = pool.imap(integrate_grid_star, zip(a_args, itertools.repeat(second_arg),itertools.repeat(third_arg),itertools.repeat(fourth_arg),itertools.repeat(fifth_arg),itertools.repeat(sixth_arg),itertools.repeat(seventh_arg),itertools.repeat(eighth_arg),itertools.repeat(ninth_arg),itertools.repeat(tenth_arg),itertools.repeat(eleventh_arg),twelvth_arg),5) #I carrie Filion edited this
-    #pool.map(integrate_grid_star, zip(a_args, itertools.repeat(second_arg),itertools.repeat(third_arg),itertools.repeat(fourth_arg),itertools.repeat(fifth_arg),itertools.repeat(sixth_arg),itertools.repeat(seventh_arg),itertools.repeat(eighth_arg),itertools.repeat(ninth_arg),itertools.repeat(tenth_arg),itertools.repeat(eleventh_arg),twelvth_arg))
+    out_vals = pool.map(integrate_grid_star, zip(a_args, itertools.repeat(second_arg),itertools.repeat(third_arg),itertools.repeat(fourth_arg),itertools.repeat(fifth_arg),itertools.repeat(sixth_arg),itertools.repeat(seventh_arg),itertools.repeat(eighth_arg),itertools.repeat(ninth_arg),itertools.repeat(tenth_arg),itertools.repeat(eleventh_arg),twelvth_arg))
+    #pool.imap(integrate_grid_star, zip(a_args, itertools.repeat(second_arg),itertools.repeat(third_arg),itertools.repeat(fourth_arg),itertools.repeat(fifth_arg),itertools.repeat(sixth_arg),itertools.repeat(seventh_arg),itertools.repeat(eighth_arg),itertools.repeat(ninth_arg),itertools.repeat(tenth_arg),itertools.repeat(eleventh_arg),twelvth_arg),5)
     #
     # clean up to exit
     pool.close()
@@ -462,7 +462,7 @@ def re_form_orbit_arrays(array):
 
 
 
-
+'''
 def print_orbit_array(f,OrbitArray):
     
     for rad in range(0,OrbitArray.shape[0]):
@@ -485,7 +485,22 @@ def print_orbit_array(f,OrbitArray):
 
             # force end of line
             print('',file=f)
-
+'''
+def print_orbit_array(f,OrbitArray):
+    for rad in range(0,OrbitArray.shape[0]):
+        for vel in range(0,OrbitArray.shape[1]):
+            # find non-zero values
+            try:
+                nsteps = np.where(OrbitArray[rad,vel,4] == 0.)[0][1]
+            except:
+                nsteps = OrbitArray.shape[3]
+            #
+            print(nsteps,OrbitArray[rad,vel,0,0],OrbitArray[rad,vel,3,0],OrbitArray[rad,vel,4,1],end=' ',file=f)
+            for x in range(0,nsteps):
+                print(OrbitArray[rad,vel,0,x],end=' ',file=f)
+            for x in range(0,nsteps):
+                print(OrbitArray[rad,vel,1,x],end=' ',file=f)
+            print('',file=f) # end the line
 
 
 def run_time(simulation_directory,simulation_name,\


### PR DESCRIPTION
This edit will generate a new workflow that is roughly sketched below. Thanks to @CarrieFilion !

```
from exptool import integrate,commensurability
initpos = np.linspace(0.002,0.05,128)
initvel = np.linspace(-0.4,vcirc*1.2,100)
integrate.run_time_mod(args)
D = commensurability.read_integrations(args)
Aarr = commensurability.calculate_area_array(D,ratio=10.)
commensurability.plot_orbit_areas(Aarr, initpos, initvel)
```